### PR TITLE
Change affiliations to Databricks Inc.

### DIFF
--- a/_data/conference.yml
+++ b/_data/conference.yml
@@ -173,7 +173,7 @@ technical_program_committee:
     org: Los Alamos National Laboratory (USA)
     homepage:
   - name: Nikunj Gupta
-    org: Amazon (USA)
+    org: Databricks Inc. (USA)
     homepage:
   - name: Jonas Posner
     org: University of Kassel (Germany)


### PR DESCRIPTION
I stopped working for Amazon as of June 2024. I'm updating my affiliations to Databricks Inc. where I currently work.